### PR TITLE
remove abs() for unsigned int

### DIFF
--- a/upgrade/upgrade.c
+++ b/upgrade/upgrade.c
@@ -620,6 +620,15 @@ finish:
 		printf("upgrade crc check failed !\n");
 		server->upgrade_flag = false;
         system_upgrade_flag_set(UPGRADE_FLAG_IDLE);	
+	} else {		
+		if(retry_count == UPGRADE_RETRY_TIMES){
+			/*retry too many times, fail*/
+			server->upgrade_flag = false;
+			system_upgrade_flag_set(UPGRADE_FLAG_IDLE);
+		}else{
+			server->upgrade_flag = true;
+			system_upgrade_flag_set(UPGRADE_FLAG_FINISH);
+		}
 	}
 
     if(NULL != precv_buf) {
@@ -629,17 +638,7 @@ finish:
     totallength = 0;
     sumlength = 0;
     flash_erased=FALSE;
-
-    if(retry_count == UPGRADE_RETRY_TIMES){
-        /*retry too many times, fail*/
-        server->upgrade_flag = false;
-        system_upgrade_flag_set(UPGRADE_FLAG_IDLE);
-
-    }else{
-        server->upgrade_flag = true;
-        system_upgrade_flag_set(UPGRADE_FLAG_FINISH);
-    }
-    
+      
     upgrade_deinit();
     
     os_printf("\n Exit upgrade task.\n");

--- a/upgrade/upgrade_crc32.c
+++ b/upgrade/upgrade_crc32.c
@@ -115,7 +115,6 @@ upgrade_crc_check(uint16 fw_bin_sec ,unsigned int sumlength)
 	if (ret < 0) {
 		return false;
 	}
-	img_crc = abs(img_crc);
 	os_printf("img_crc = %u\n",img_crc);
 	spi_flash_read(start_sec * SPI_FLASH_SEC_SIZE + sumlength - 4,&flash_crc, 4);
     os_printf("flash_crc = %u\n",flash_crc);


### PR DESCRIPTION
Hi! 
1) I think that using abs() function for unsigned int is incorrect and senselessy.
2) Checking of retry_count is actual for right crc. Otherwise checking of retry_count executes and we can get upgarde_flag is true.  
